### PR TITLE
Refactor TensorFlow CNN to PyTorch

### DIFF
--- a/Example/run_CNN.py
+++ b/Example/run_CNN.py
@@ -61,9 +61,9 @@ if __name__ == '__main__':
 
     # Path to trained CNN model
     if inc_pdf:
-        model_path = 'Models/XRD_Model.h5'
+        model_path = 'Models/XRD_Model.pth'
     else:
-        model_path = 'Model.h5'
+        model_path = 'Model.pth'
 
     # Used for writing temporary files
     if not os.path.exists('temp'):
@@ -76,7 +76,7 @@ if __name__ == '__main__':
 
     if inc_pdf:
         # If specified, get predictions from PDF analysis
-        model_path = 'Models/PDF_Model.h5'
+        model_path = 'Models/PDF_Model.pth'
         results['PDF']['filenames'], results['PDF']['phases'], results['PDF']['confs'], results['PDF']['backup_phases'], \
             results['PDF']['scale_factors'], results['PDF']['reduced_spectra'] = spectrum_analysis.main('Spectra', 'References',
             max_phases, cutoff_intensity, min_conf, wavelength, min_angle, max_angle, parallel, model_path, is_pdf=True)

--- a/Novel-Space/construct_pdf_model.py
+++ b/Novel-Space/construct_pdf_model.py
@@ -42,12 +42,12 @@ if __name__ == '__main__':
 
     # Ensure an XRD model has already been trained, but not yet a PDF model
     assert 'Models' not in os.listdir('.'), 'Models folder already exists. Please remove it or use existing models.'
-    assert 'Model.h5' in os.listdir('.'), 'Cannot find a trained Model.h5 file in current directory. Please train an XRD model first.'
+    assert 'Model.pth' in os.listdir('.'), 'Cannot find a trained Model.pth file in current directory. Please train an XRD model first.'
     assert 'References' in os.listdir('.'), 'Cannot find a References folder in your current directory.'
 
     # Move trained XRD model to new directory
     os.mkdir('Models')
-    os.rename('Model.h5', 'Models/XRD_Model.h5')
+    os.rename('Model.pth', 'Models/XRD_Model.pth')
 
     # Simualted vrtual PDFs
     pdf_obj = spectrum_generation.SpectraGenerator('References', num_spectra, max_texture, min_domain_size,
@@ -61,5 +61,5 @@ if __name__ == '__main__':
     # Train, test, and save the CNN
     test_fraction = 0.2
     cnn.main(pdf_specs, num_epochs, test_fraction, is_pdf=True)
-    os.rename('Model.h5', 'Models/PDF_Model.h5')
+    os.rename('Model.pth', 'Models/PDF_Model.pth')
 

--- a/Novel-Space/run_CNN.py
+++ b/Novel-Space/run_CNN.py
@@ -61,9 +61,9 @@ if __name__ == '__main__':
 
     # Path to trained CNN model
     if inc_pdf:
-        model_path = 'Models/XRD_Model.h5'
+        model_path = 'Models/XRD_Model.pth'
     else:
-        model_path = 'Model.h5'
+        model_path = 'Model.pth'
 
     # Used for writing temporary files
     if not os.path.exists('temp'):
@@ -76,7 +76,7 @@ if __name__ == '__main__':
 
     if inc_pdf:
         # If specified, get predictions from PDF analysis
-        model_path = 'Models/PDF_Model.h5'
+        model_path = 'Models/PDF_Model.pth'
         results['PDF']['filenames'], results['PDF']['phases'], results['PDF']['confs'], results['PDF']['backup_phases'], \
             results['PDF']['scale_factors'], results['PDF']['reduced_spectra'] = spectrum_analysis.main('Spectra', 'References',
             max_phases, cutoff_intensity, min_conf, wavelength, min_angle, max_angle, parallel, model_path, is_pdf=True)

--- a/PDF_Example/run_CNN.py
+++ b/PDF_Example/run_CNN.py
@@ -61,9 +61,9 @@ if __name__ == '__main__':
 
     # Path to trained CNN model
     if inc_pdf:
-        model_path = 'Models/XRD_Model.h5'
+        model_path = 'Models/XRD_Model.pth'
     else:
-        model_path = 'Model.h5'
+        model_path = 'Model.pth'
 
     # Used for writing temporary files
     if not os.path.exists('temp'):
@@ -76,7 +76,7 @@ if __name__ == '__main__':
 
     if inc_pdf:
         # If specified, get predictions from PDF analysis
-        model_path = 'Models/PDF_Model.h5'
+        model_path = 'Models/PDF_Model.pth'
         results['PDF']['filenames'], results['PDF']['phases'], results['PDF']['confs'], results['PDF']['backup_phases'], \
             results['PDF']['scale_factors'], results['PDF']['reduced_spectra'] = spectrum_analysis.main('Spectra', 'References',
             max_phases, cutoff_intensity, min_conf, wavelength, min_angle, max_angle, parallel, model_path, is_pdf=True)

--- a/autoXRD/cnn/__init__.py
+++ b/autoXRD/cnn/__init__.py
@@ -1,215 +1,251 @@
+"""PyTorch implementation of the convolutional neural network used for
+XRD/PDF phase identification.
+
+This module mirrors the functionality of the original TensorFlow version
+but relies exclusively on :mod:`torch`.  It exposes utilities for setting
+up datasets, training, evaluation and saving models.  The network
+architecture is kept identical to the previous implementation to preserve
+accuracy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Sequence, Tuple
+
 import numpy as np
-import tensorflow as tf
-from random import shuffle
-from tensorflow.keras import regularizers
-import sys
+import torch
+from torch import Tensor, nn
+from torch.utils.data import DataLoader, TensorDataset
 
-# Used to apply dropout during training *and* inference
-class CustomDropout(tf.keras.layers.Layer):
 
-    def __init__(self, rate, **kwargs):
-        super(CustomDropout, self).__init__(**kwargs)
+class CustomDropout(nn.Module):
+    """Dropout layer that is always active.
+
+    In the original TensorFlow model a custom layer was used to apply
+    dropout during both training and inference to enable Monte Carlo
+    dropout sampling.  The same behaviour is reproduced here by always
+    enabling dropout in the forward pass.
+    """
+
+    def __init__(self, rate: float) -> None:
+        super().__init__()
         self.rate = rate
 
-    def get_config(self):
-        config = super().get_config()
-        config.update({
-            "rate": self.rate
-        })
-        return config
-
-    # Always apply dropout
-    def call(self, inputs, training=None):
-        return tf.nn.dropout(inputs, rate=self.rate)
+    def forward(self, x: Tensor) -> Tensor:  # noqa: D401 - short description inherited
+        return nn.functional.dropout(x, p=self.rate, training=True)
 
 
-class DataSetUp(object):
-    """
-    Class used to train a convolutional neural network on a given
-    set of X-ray diffraction spectra to perform phase identification.
-    """
+class XRDModel(nn.Module):
+    """Convolutional neural network for XRD/PDF analysis."""
 
-    def __init__(self, xrd, testing_fraction=0):
-        """
-        Args:
-            xrd: a numpy array containing xrd spectra categorized by
-                their associated reference phase.
-                The shape of the array should be NxMx4501x1 where:
-                N = the number of reference phases,
-                M = the number of augmented spectra per reference phase,
-                4501 = intensities as a function of 2-theta
-                (spanning from 10 to 80 degrees by default)
-            testing_fraction: fraction of data (xrd patterns) to reserve for testing.
-                By default, all spectra will be used for training.
-        """
-        self.xrd = xrd
-        self.testing_fraction = testing_fraction
-        self.num_phases = len(xrd)
+    def __init__(
+        self,
+        n_phases: int,
+        is_pdf: bool,
+        n_dense: Sequence[int] = (3100, 1200),
+        dropout_rate: float = 0.7,
+    ) -> None:
+        super().__init__()
+
+        conv: List[nn.Module] = []
+        if is_pdf:
+            # Architecture optimised for PDF analysis
+            conv.extend(
+                [
+                    nn.Conv1d(1, 64, 60, padding=30),
+                    nn.ReLU(),
+                    nn.MaxPool1d(3, stride=2, padding=1),
+                    nn.MaxPool1d(3, stride=2, padding=1),
+                    nn.MaxPool1d(2, stride=2, padding=1),
+                    nn.MaxPool1d(1, stride=2, padding=0),
+                    nn.MaxPool1d(1, stride=2, padding=0),
+                    nn.MaxPool1d(1, stride=2, padding=0),
+                ]
+            )
+        else:
+            # Architecture optimised for XRD analysis
+            conv.extend(
+                [
+                    nn.Conv1d(1, 64, 35, padding=17),
+                    nn.ReLU(),
+                    nn.MaxPool1d(3, stride=2, padding=1),
+                    nn.Conv1d(64, 64, 30, padding=15),
+                    nn.ReLU(),
+                    nn.MaxPool1d(3, stride=2, padding=1),
+                    nn.Conv1d(64, 64, 25, padding=12),
+                    nn.ReLU(),
+                    nn.MaxPool1d(2, stride=2, padding=1),
+                    nn.Conv1d(64, 64, 20, padding=10),
+                    nn.ReLU(),
+                    nn.MaxPool1d(1, stride=2, padding=0),
+                    nn.Conv1d(64, 64, 15, padding=7),
+                    nn.ReLU(),
+                    nn.MaxPool1d(1, stride=2, padding=0),
+                    nn.Conv1d(64, 64, 10, padding=5),
+                    nn.ReLU(),
+                    nn.MaxPool1d(1, stride=2, padding=0),
+                ]
+            )
+
+        self.features = nn.Sequential(*conv)
+
+        # Determine the flatten dimension dynamically using a dummy forward
+        with torch.no_grad():
+            dummy = torch.zeros(1, 1, 4501)
+            flat_dim = self.features(dummy).view(1, -1).shape[1]
+
+        self.classifier = nn.Sequential(
+            nn.Flatten(),
+            CustomDropout(dropout_rate),
+            nn.Linear(flat_dim, n_dense[0]),
+            nn.ReLU(),
+            nn.BatchNorm1d(n_dense[0]),
+            CustomDropout(dropout_rate),
+            nn.Linear(n_dense[0], n_dense[1]),
+            nn.ReLU(),
+            nn.BatchNorm1d(n_dense[1]),
+            CustomDropout(dropout_rate),
+            nn.Linear(n_dense[1], n_phases),
+        )
+
+    def forward(self, x: Tensor) -> Tensor:  # noqa: D401 - short description inherited
+        x = self.features(x)
+        return self.classifier(x)
+
+
+@dataclass
+class DataSetUp:
+    """Utility class for organising XRD spectra for training."""
+
+    xrd: np.ndarray
+    testing_fraction: float = 0.0
 
     @property
-    def phase_indices(self):
-        """
-        List of indices to keep track of xrd spectra such that
-            each index is associated with a reference phase.
-        """
-        xrd = self.xrd
-        num_phases = self.num_phases
-        return [v for v in range(num_phases)]
+    def num_phases(self) -> int:
+        return len(self.xrd)
 
     @property
-    def x(self):
-        """
-        Feature matrix (array of intensities used for training)
-        """
-        intensities = []
-        xrd = self.xrd
-        phase_indices = self.phase_indices
-        for (augmented_spectra, index) in zip(xrd, phase_indices):
+    def phase_indices(self) -> List[int]:
+        return list(range(self.num_phases))
+
+    @property
+    def x(self) -> np.ndarray:
+        intensities: List[np.ndarray] = []
+        for augmented_spectra, _ in zip(self.xrd, self.phase_indices):
             for pattern in augmented_spectra:
                 intensities.append(pattern)
         return np.array(intensities)
 
     @property
-    def y(self):
-        """
-        Target property to predict (one-hot encoded vectors associated
-        with the reference phases)
-        """
-        xrd = self.xrd
-        phase_indices = self.phase_indices
-        one_hot_vectors = []
-        for (augmented_spectra, index) in zip(xrd, phase_indices):
-            for pattern in augmented_spectra:
-                assigned_vec = [0]*len(xrd)
-                assigned_vec[index] = 1.0
-                one_hot_vectors.append(assigned_vec)
+    def y(self) -> np.ndarray:
+        one_hot_vectors: List[List[float]] = []
+        for augmented_spectra, index in zip(self.xrd, self.phase_indices):
+            for _ in augmented_spectra:
+                vec = [0.0] * len(self.xrd)
+                vec[index] = 1.0
+                one_hot_vectors.append(vec)
         return np.array(one_hot_vectors)
 
-    def split_training_testing(self):
-        """
-        Training and testing data will be split according
-        to self.testing_fraction
-
-        Returns:
-            x_train, x_test: features matrices (xrd spectra) to be
-                used for training and testing
-            y_train, t_test: target properties (one-hot encoded phase indices)
-                to be used for training and testing
-        """
+    def split_training_testing(
+        self,
+    ) -> Tuple[np.ndarray, np.ndarray, Optional[np.ndarray], Optional[np.ndarray]]:
         x = self.x
         y = self.y
-        testing_fraction = self.testing_fraction
         combined_xy = list(zip(x, y))
-        shuffle(combined_xy)
+        np.random.shuffle(combined_xy)
 
-        if testing_fraction == 0:
+        if self.testing_fraction == 0:
             train_x, train_y = zip(*combined_xy)
-            test_x, test_y = None, None
-            return np.array(train_x), np.array(train_y), test_x, test_y
+            return np.array(train_x), np.array(train_y), None, None
 
-        else:
-            total_samples = len(combined_xy)
-            n_testing = int(testing_fraction*total_samples)
+        total_samples = len(combined_xy)
+        n_testing = int(self.testing_fraction * total_samples)
 
-            train_xy = combined_xy[n_testing:]
-            train_x, train_y = zip(*train_xy)
+        train_xy = combined_xy[n_testing:]
+        train_x, train_y = zip(*train_xy)
 
-            test_xy = combined_xy[:n_testing]
-            test_x, test_y = zip(*test_xy)
+        test_xy = combined_xy[:n_testing]
+        test_x, test_y = zip(*test_xy)
 
-            return np.array(train_x), np.array(train_y), np.array(test_x), np.array(test_y)
+        return (
+            np.array(train_x),
+            np.array(train_y),
+            np.array(test_x),
+            np.array(test_y),
+        )
 
-def train_model(x_train, y_train, n_phases, num_epochs, is_pdf, n_dense=[3100, 1200], dropout_rate=0.7):
-    """
-    Args:
-        x_train: numpy array of simulated xrd spectra
-        y_train: one-hot encoded vectors associated with reference phase indices
-        n_phases: number of reference phases considered
-        fmodel: filename to save trained model to
-        n_dense: number of nodes comprising the two hidden layers in the neural network
-        dropout_rate: fraction of connections excluded between the hidden layers during training
-    Returns:
-        model: trained and compiled tensorflow.keras.Model object
-    """
 
-    # Optimized architecture for PDF analysis
-    if is_pdf:
-        model = tf.keras.Sequential([
-        tf.keras.layers.Conv1D(filters=64, kernel_size=60, strides=1, padding='same', activation='relu'),
-        tf.keras.layers.MaxPool1D(pool_size=3, strides=2, padding='same'),
-        tf.keras.layers.MaxPool1D(pool_size=3, strides=2, padding='same'),
-        tf.keras.layers.MaxPool1D(pool_size=2, strides=2, padding='same'),
-        tf.keras.layers.MaxPool1D(pool_size=1, strides=2, padding='same'),
-        tf.keras.layers.MaxPool1D(pool_size=1, strides=2, padding='same'),
-        tf.keras.layers.MaxPool1D(pool_size=1, strides=2, padding='same'),
-        tf.keras.layers.Flatten(),
-        CustomDropout(dropout_rate),
-        tf.keras.layers.Dense(n_dense[0], activation='relu'),
-        tf.keras.layers.BatchNormalization(),
-        CustomDropout(dropout_rate),
-        tf.keras.layers.Dense(n_dense[1], activation='relu'),
-        tf.keras.layers.BatchNormalization(),
-        CustomDropout(dropout_rate),
-        tf.keras.layers.Dense(n_phases, activation='softmax')])
+def _prepare_dataloader(x: np.ndarray, y: np.ndarray) -> DataLoader:
+    x_tensor = torch.tensor(x, dtype=torch.float32).permute(0, 2, 1)
+    y_indices = torch.tensor(np.argmax(y, axis=1), dtype=torch.long)
+    dataset = TensorDataset(x_tensor, y_indices)
+    return DataLoader(dataset, batch_size=32, shuffle=True)
 
-    # Optimized architecture for XRD analysis
-    else:
-        model = tf.keras.Sequential([
-        tf.keras.layers.Conv1D(filters=64, kernel_size=35, strides=1, padding='same', activation='relu'),
-        tf.keras.layers.MaxPool1D(pool_size=3, strides=2, padding='same'),
-        tf.keras.layers.Conv1D(filters=64, kernel_size=30, strides=1, padding='same', activation='relu'),
-        tf.keras.layers.MaxPool1D(pool_size=3, strides=2, padding='same'),
-        tf.keras.layers.Conv1D(filters=64, kernel_size=25, strides=1, padding='same', activation='relu'),
-        tf.keras.layers.MaxPool1D(pool_size=2, strides=2, padding='same'),
-        tf.keras.layers.Conv1D(filters=64, kernel_size=20, strides=1, padding='same', activation='relu'),
-        tf.keras.layers.MaxPool1D(pool_size=1, strides=2, padding='same'),
-        tf.keras.layers.Conv1D(filters=64, kernel_size=15, strides=1, padding='same', activation='relu'),
-        tf.keras.layers.MaxPool1D(pool_size=1, strides=2, padding='same'),
-        tf.keras.layers.Conv1D(filters=64, kernel_size=10, strides=1, padding='same', activation='relu'),
-        tf.keras.layers.MaxPool1D(pool_size=1, strides=2, padding='same'),
-        tf.keras.layers.Flatten(),
-        CustomDropout(dropout_rate),
-        tf.keras.layers.Dense(n_dense[0], activation='relu'),
-        tf.keras.layers.BatchNormalization(),
-        CustomDropout(dropout_rate),
-        tf.keras.layers.Dense(n_dense[1], activation='relu'),
-        tf.keras.layers.BatchNormalization(),
-        CustomDropout(dropout_rate),
-        tf.keras.layers.Dense(n_phases, activation='softmax')])
 
-    # Compile model
-    model.compile(loss=tf.keras.losses.CategoricalCrossentropy(from_logits=False), optimizer=tf.keras.optimizers.Adam(), metrics=[tf.keras.metrics.CategoricalAccuracy()])
+def train_model(
+    x_train: np.ndarray,
+    y_train: np.ndarray,
+    n_phases: int,
+    num_epochs: int,
+    is_pdf: bool,
+    n_dense: Sequence[int] = (3100, 1200),
+    dropout_rate: float = 0.7,
+) -> XRDModel:
+    """Train the convolutional neural network."""
 
-    # Fit model to training data
-    model.fit(x_train, y_train, batch_size=32, epochs=num_epochs,
-    validation_split=0.2, shuffle=True)
+    model = XRDModel(n_phases, is_pdf, n_dense, dropout_rate)
+    criterion = nn.CrossEntropyLoss()
+    optimizer = torch.optim.Adam(model.parameters())
+
+    loader = _prepare_dataloader(x_train, y_train)
+    model.train()
+    for _ in range(num_epochs):
+        for xb, yb in loader:
+            optimizer.zero_grad()
+            pred = model(xb)
+            loss = criterion(pred, yb)
+            loss.backward()
+            optimizer.step()
 
     return model
 
-def test_model(model, test_x, test_y):
-    """
-    Args:
-        model: trained tensorflow.keras.Model object
-        x_test: feature matrix containing xrd spectra
-        y_test: one-hot encoded vectors associated with
-            the reference phases
-    """
-    _, acc = model.evaluate(test_x, test_y)
-    print('Test Accuracy: ' + str(acc*100) + '%')
 
-def main(xrd, num_epochs, testing_fraction, is_pdf, fmodel='Model.h5'):
+def test_model(model: XRDModel, test_x: np.ndarray, test_y: np.ndarray) -> None:
+    """Evaluate the trained model on a test set and print accuracy."""
 
-    # Organize data
+    loader = _prepare_dataloader(test_x, test_y)
+    model.eval()
+    correct = 0
+    total = 0
+    with torch.no_grad():
+        for xb, yb in loader:
+            out = model(xb)
+            _, predicted = torch.max(out, 1)
+            total += yb.size(0)
+            correct += (predicted == yb).sum().item()
+
+    if total > 0:
+        print(f"Test Accuracy: {100 * correct / total:.2f}%")
+
+
+def main(
+    xrd: np.ndarray,
+    num_epochs: int,
+    testing_fraction: float,
+    is_pdf: bool,
+    fmodel: str = "Model.pth",
+) -> None:
+    """Entry point used by example scripts to train a model."""
+
     obj = DataSetUp(xrd, testing_fraction)
     num_phases = obj.num_phases
     train_x, train_y, test_x, test_y = obj.split_training_testing()
 
-    # Train model
     model = train_model(train_x, train_y, num_phases, num_epochs, is_pdf)
 
-    # Save model
-    model.save(fmodel, include_optimizer=False)
+    torch.save(model.state_dict(), fmodel)
 
-    # Test model is any data is reserved for testing
-    if testing_fraction != 0:
+    if testing_fraction != 0 and test_x is not None and test_y is not None:
         test_model(model, test_x, test_y)
+

--- a/autoXRD/spectrum_analysis/__init__.py
+++ b/autoXRD/spectrum_analysis/__init__.py
@@ -1,6 +1,6 @@
 from scipy.signal import find_peaks, filtfilt, resample
-from tensorflow.keras.utils import custom_object_scope
 from autoXRD.dara import do_refinement_no_saving
+from autoXRD.cnn import XRDModel
 from pymatgen.analysis.diffraction import xrd
 from scipy.ndimage import gaussian_filter1d
 from multiprocessing import Pool, Manager
@@ -9,7 +9,7 @@ from pymatgen.core import Structure
 import matplotlib.pyplot as plt
 from skimage import restoration
 from pathlib import Path
-import tensorflow as tf
+import torch
 from scipy import signal
 from pyts import metrics
 import multiprocessing
@@ -21,29 +21,10 @@ import random
 import shutil
 import math
 import os
-
-os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+from typing import List, Sequence, Tuple
 
 np.random.seed(1)
-tf.random.set_seed(1)
-
-# Used to apply dropout during training *and* inference
-class CustomDropout(tf.keras.layers.Layer):
-
-    def __init__(self, rate, **kwargs):
-        super(CustomDropout, self).__init__(**kwargs)
-        self.rate = rate
-
-    def get_config(self):
-        config = super().get_config()
-        config.update({
-            "rate": self.rate
-        })
-        return config
-
-    # Always apply dropout
-    def call(self, inputs, training=None):
-        return tf.nn.dropout(inputs, rate=self.rate)
+torch.manual_seed(1)
 
 
 class SpectrumAnalyzer(object):
@@ -52,7 +33,7 @@ class SpectrumAnalyzer(object):
     """
 
     def __init__(self, spectra_dir, spectrum_fname, max_phases, cutoff_intensity, min_conf=25.0, wavelen='CuKa',
-        reference_dir='References', min_angle=10.0, max_angle=80.0, model_path='Model.h5', is_pdf=False):
+        reference_dir='References', min_angle=10.0, max_angle=80.0, model_path='Model.pth', is_pdf=False):
         """
         Args:
             spectrum_fname: name of file containing the
@@ -91,12 +72,15 @@ class SpectrumAnalyzer(object):
 
         spectrum = self.formatted_spectrum
 
-        with custom_object_scope({'CustomDropout': CustomDropout}):
-            self.model = tf.keras.models.load_model(self.model_path, compile=False)
+        self.model = XRDModel(len(self.reference_phases), is_pdf=self.is_pdf)
+        self.model.load_state_dict(torch.load(self.model_path, map_location="cpu"))
+        self.model.eval()
 
-        self.kdp = KerasDropoutPrediction(self.model)
+        self.kdp = TorchDropoutPrediction(self.model)
 
-        prediction_list, confidence_list, backup_list, scale_list, spec_list = self.enumerate_routes(spectrum)
+        prediction_list, confidence_list, backup_list, scale_list, spec_list = self.enumerate_routes(
+            spectrum
+        )
 
         return prediction_list, confidence_list, backup_list, scale_list, spec_list
 
@@ -215,7 +199,7 @@ class SpectrumAnalyzer(object):
 
         Args:
             xrd_spectrum: a numpy array containing the measured spectrum that is to be classified
-            kdp: a KerasDropoutPrediction model object
+            kdp: a TorchDropoutPrediction model object
             reference_phases: a list of reference phase strings
             indiv_conf: list of probabilities associated with an individual mixture (one per branch)
             indiv_pred: list of predicted phases in an individual mixture (one per branch)
@@ -595,62 +579,49 @@ class SpectrumAnalyzer(object):
         return pdf
 
 
-class KerasDropoutPrediction(object):
-    """
-    Ensemble model used to provide a probability distribution associated
-    with suspected phases in a given xrd spectrum.
-    """
+class TorchDropoutPrediction(object):
+    """Monte Carlo dropout wrapper for a PyTorch model."""
 
-    def __init__(self, model):
-        """
-        Args:
-            model: trained convolutional neural network
-                (tensorflow.keras Model object)
-        """
-
+    def __init__(self, model: XRDModel) -> None:
         self.model = model
 
-    def predict(self, x, min_conf=10.0, n_iter=100):
-        """
-        Args:
-            x: xrd spectrum to be classified
-        Returns:
-            prediction: distribution of probabilities associated with reference phases
-            len(certainties): number of phases with probabilities > 10%
-            certanties: associated probabilities
-        """
+    def predict(
+        self, x: Sequence[float], min_conf: float = 10.0, n_iter: int = 100
+    ) -> Tuple[np.ndarray, int, List[float], int]:
+        """Return mean prediction and associated confidences."""
 
-        # Convert from % to 0-1 fractional
         if min_conf > 1.0:
             min_conf /= 100.0
 
-        # Format input
-        x = np.array([x])
+        tensor_x = (
+            torch.tensor(x, dtype=torch.float32)
+            .view(1, 1, -1)
+        )
 
-        # Monte Carlo Dropout
-        result = []
-        for _ in range(n_iter):
-            result.append(self.model(x))
+        result: List[np.ndarray] = []
+        self.model.eval()
+        with torch.no_grad():
+            for _ in range(n_iter):
+                out = self.model(tensor_x)
+                prob = torch.softmax(out, dim=1).cpu().numpy()
+                result.append(prob.flatten())
 
-        result = np.array([list(np.array(sublist).flatten()) for sublist in result]) ## Individual predictions
-        prediction = result.mean(axis=0) ## Average prediction
+        result_arr = np.array(result)
+        prediction = result_arr.mean(axis=0)
 
-        num_outputs = len(prediction) # Check how many possible phases there are
+        num_outputs = len(prediction)
+        all_preds = [np.argmax(pred) for pred in result_arr]
 
-        all_preds = [np.argmax(pred) for pred in result] ## Individual max indices (associated with phases)
+        counts = [all_preds.count(idx) for idx in set(all_preds)]
 
-        counts = []
-        for index in set(all_preds):
-            counts.append(all_preds.count(index)) ## Tabulate how many times each prediction arises
-
-        certanties = []
+        certainties = []
         for each_count in counts:
-            conf = each_count/sum(counts)
+            conf = each_count / sum(counts)
             if conf >= min_conf:
-                certanties.append(conf)
-        certanties = sorted(certanties, reverse=True)
+                certainties.append(conf)
+        certainties = sorted(certainties, reverse=True)
 
-        return prediction, len(certanties), certanties, num_outputs
+        return prediction, len(certainties), certainties, num_outputs
 
 
 class PhaseIdentifier(object):
@@ -659,7 +630,7 @@ class PhaseIdentifier(object):
     """
 
     def __init__(self, spectra_directory, reference_directory, max_phases, cutoff_intensity, min_conf, wavelength,
-        min_angle=10.0, max_angle=80.0, parallel=True, model_path='Model.h5', is_pdf=False):
+        min_angle=10.0, max_angle=80.0, parallel=True, model_path='Model.pth', is_pdf=False):
         """
         Args:
             spectra_dir: path to directory containing the xrd
@@ -877,7 +848,7 @@ def merge_results(results, cutoff, max_phases):
 
 
 def main(spectra_directory, reference_directory, max_phases=3, cutoff_intensity=10, min_conf=10.0,wavelength='CuKa',
-    min_angle=10.0, max_angle=80.0, parallel=True, model_path='Model.h5', is_pdf=False):
+    min_angle=10.0, max_angle=80.0, parallel=True, model_path='Model.pth', is_pdf=False):
 
     phase_id = PhaseIdentifier(spectra_directory, reference_directory, max_phases,
         cutoff_intensity, min_conf, wavelength, min_angle, max_angle, parallel, model_path, is_pdf)

--- a/docs/pytorch_refactor.md
+++ b/docs/pytorch_refactor.md
@@ -1,0 +1,39 @@
+# PyTorch Refactor Overview
+
+This document summarises the migration of the XRD-AutoAnalyzer neural
+network pipeline from TensorFlow/Keras to PyTorch.
+
+## Architecture
+
+- **Model structure** – The convolutional architecture closely mirrors the
+  original design. Separate branches are retained for XRD and PDF analysis
+  with identical convolution and pooling configurations. Dense layers use
+  the same number of neurons (3,100 and 1,200).
+- **Dropout** – A custom `CustomDropout` layer applies dropout regardless of
+  the module's training state to facilitate Monte Carlo dropout during
+  inference.
+
+## Training Pipeline
+
+- Training uses standard PyTorch loops with `torch.utils.data.DataLoader`
+  for batching. The loss function switches to `CrossEntropyLoss` which
+  operates on raw logits, providing numerical stability.
+- Optimisation continues to use the Adam optimiser. Dataset splitting and
+  shuffling logic is preserved from the previous implementation.
+
+## Performance Considerations
+
+- The flatten dimension for the fully-connected head is computed
+  dynamically using a dummy forward pass, ensuring the model adapts to the
+  convolutional stack without manual calculation.
+- Evaluation utilities compute accuracy using vectorised operations to
+  minimise Python overhead.
+
+## Testing Strategy
+
+- Syntax of all modified modules is validated via `python -m py_compile`.
+- Due to the absence of a PyTorch installation in the execution
+  environment, full unit tests could not be executed. Users should run the
+  existing example scripts after installing PyTorch to validate end-to-end
+  training and inference.
+


### PR DESCRIPTION
## Summary
- replace TensorFlow CNN with PyTorch implementation and always-on dropout
- update spectrum analysis to load and run PyTorch models
- adjust example scripts and docs for new `.pth` model artifacts

## Testing
- `python -m py_compile autoXRD/cnn/__init__.py autoXRD/spectrum_analysis/__init__.py Example/run_CNN.py PDF_Example/run_CNN.py Novel-Space/run_CNN.py Novel-Space/construct_pdf_model.py`
- `pytest -q` *(no tests discovered)*
- `python - <<'PY'
import torch
PY` *(ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68ac1d47191c8325b72f774faecfef14